### PR TITLE
Add divergence indicator dropdown

### DIFF
--- a/echonode/gui.py
+++ b/echonode/gui.py
@@ -6,12 +6,43 @@ from pathlib import Path
 
 import pandas as pd
 import ccxt
-from PyQt5 import QtWidgets, QtCore
+from PyQt5 import QtWidgets, QtCore, QtGui
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 import mplfinance as mpf
 
 from .trading import get_exchange, place_order
+from .indicators import compute_divergence
+
+
+class IndicatorPopup(QtWidgets.QListWidget):
+    """Popup list for toggling indicators."""
+
+    toggled = QtCore.pyqtSignal(str, bool)
+
+    def __init__(self, indicators: list[str]):
+        super().__init__()
+        self.setWindowFlags(QtCore.Qt.Popup)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+        for name in indicators:
+            item = QtWidgets.QListWidgetItem(name)
+            item.setFlags(item.flags() | QtCore.Qt.ItemIsUserCheckable)
+            item.setCheckState(QtCore.Qt.Unchecked)
+            self.addItem(item)
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent):
+        item = self.itemAt(event.pos())
+        if item is not None:
+            checked = item.checkState() == QtCore.Qt.Checked
+            item.setCheckState(QtCore.Qt.Unchecked if checked else QtCore.Qt.Checked)
+            self.toggled.emit(item.text(), not checked)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def focusOutEvent(self, event: QtGui.QFocusEvent):
+        self.hide()
+        super().focusOutEvent(event)
 
 DATA_DIR = Path(__file__).resolve().parent / "data" / "ohlcv_data"
 DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -26,18 +57,35 @@ class CandlestickCanvas(FigureCanvas):
         self.setParent(parent)
         self.ax = self.fig.add_subplot(111)
         self._data = pd.DataFrame()
+        self.indicator_data: dict[str, pd.DataFrame] = {}
+        self.indicators_enabled: dict[str, bool] = {"Divergence": False}
         self.mpl_connect("motion_notify_event", self.on_mouse_move)
         self._crosshair_v = self.ax.axvline(color="gray", lw=0.5, ls="--")
         self._crosshair_h = self.ax.axhline(color="gray", lw=0.5, ls="--")
 
+    def set_indicator_state(self, name: str, state: bool):
+        self.indicators_enabled[name] = state
+        self.redraw()
+
     def load_data(self, df: pd.DataFrame):
         self._data = df
+        # pre-compute indicator data
+        self.indicator_data["Divergence"] = compute_divergence(df)
         self.redraw()
 
     def redraw(self):
         self.ax.clear()
         if not self._data.empty:
             mpf.plot(self._data, type="candle", ax=self.ax, datetime_format="%H:%M")
+            if self.indicators_enabled.get("Divergence"):
+                div = self.indicator_data.get("Divergence")
+                if div is not None:
+                    bulls = div["Bullish"].dropna()
+                    bears = div["Bearish"].dropna()
+                    if not bulls.empty:
+                        self.ax.scatter(bulls.index, bulls.values, marker="^", color="green", zorder=5)
+                    if not bears.empty:
+                        self.ax.scatter(bears.index, bears.values, marker="v", color="red", zorder=5)
         self.draw()
 
     def on_mouse_move(self, event):
@@ -62,13 +110,19 @@ class MainWindow(QtWidgets.QWidget):
         self.canvas = CandlestickCanvas(self)
         self.buy_button = QtWidgets.QPushButton("Buy")
         self.sell_button = QtWidgets.QPushButton("Sell")
+        self.indicator_button = QtWidgets.QPushButton("Indicators")
+        self.indicator_popup = IndicatorPopup(["Divergence"])
+        self.indicator_popup.toggled.connect(self.canvas.set_indicator_state)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.addWidget(self.canvas)
         buttons = QtWidgets.QHBoxLayout()
         buttons.addWidget(self.buy_button)
         buttons.addWidget(self.sell_button)
+        buttons.addWidget(self.indicator_button)
         layout.addLayout(buttons)
+
+        self.indicator_button.clicked.connect(self.show_indicator_popup)
 
         self.buy_button.clicked.connect(lambda: self.place_order("buy"))
         self.sell_button.clicked.connect(lambda: self.place_order("sell"))
@@ -78,6 +132,11 @@ class MainWindow(QtWidgets.QWidget):
         self.timer.start(60_000)  # update every minute
 
         self.update_chart()
+
+    def show_indicator_popup(self):
+        pos = self.indicator_button.mapToGlobal(QtCore.QPoint(0, self.indicator_button.height()))
+        self.indicator_popup.move(pos)
+        self.indicator_popup.show()
 
     def _get_exchange(self):
         if self.exchange is None:

--- a/echonode/indicators/__init__.py
+++ b/echonode/indicators/__init__.py
@@ -1,0 +1,5 @@
+"""Technical analysis indicators."""
+
+from .divergence import compute_divergence
+
+__all__ = ["compute_divergence"]

--- a/echonode/indicators/divergence.py
+++ b/echonode/indicators/divergence.py
@@ -1,0 +1,52 @@
+"""Simple divergence indicator based on RSI."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def rsi(series: pd.Series, period: int = 14) -> pd.Series:
+    """Calculate Relative Strength Index."""
+    delta = series.diff()
+    gain = delta.where(delta > 0, 0.0)
+    loss = -delta.where(delta < 0, 0.0)
+    avg_gain = gain.rolling(window=period).mean()
+    avg_loss = loss.rolling(window=period).mean()
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def compute_divergence(df: pd.DataFrame, lookback: int = 20) -> pd.DataFrame:
+    """Return bullish and bearish divergence points.
+
+    Parameters
+    ----------
+    df : DataFrame
+        OHLCV data indexed by datetime.
+    lookback : int, optional
+        Bars to look back when comparing highs/lows, by default 20.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame with 'Bullish' and 'Bearish' columns containing price
+        levels for plotting divergence markers.
+    """
+    data = df.copy()
+    data["RSI"] = rsi(data["Close"])
+    data["Bullish"] = float("nan")
+    data["Bearish"] = float("nan")
+
+    for i in range(lookback, len(data)):
+        cur_low = data["Low"].iloc[i]
+        prev_low = data["Low"].iloc[i - lookback]
+        cur_rsi = data["RSI"].iloc[i]
+        prev_rsi = data["RSI"].iloc[i - lookback]
+        if cur_low < prev_low and cur_rsi > prev_rsi:
+            data.at[data.index[i], "Bullish"] = cur_low * 0.995
+        cur_high = data["High"].iloc[i]
+        prev_high = data["High"].iloc[i - lookback]
+        if cur_high > prev_high and cur_rsi < prev_rsi:
+            data.at[data.index[i], "Bearish"] = cur_high * 1.005
+
+    return data[["Bullish", "Bearish"]]


### PR DESCRIPTION
## Summary
- introduce `echonode.indicators` with a divergence indicator implementation
- add an indicator popup menu to the GUI
- allow toggling divergence signals on the chart

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685042571f8c83269b0e18d7628704eb